### PR TITLE
Fix 5 code scanning alerts

### DIFF
--- a/lib/insecurity.ts
+++ b/lib/insecurity.ts
@@ -133,6 +133,9 @@ export const redirectAllowlist = new Set([
 ])
 
 export const isRedirectAllowed = (url: string) => {
+  if (typeof url !== 'string') {
+    return false
+  }
   let allowed = false
   for (const allowedUrl of redirectAllowlist) {
     allowed = allowed || url.includes(allowedUrl) // vuln-code-snippet vuln-line redirectChallenge

--- a/routes/dataErasure.ts
+++ b/routes/dataErasure.ts
@@ -69,9 +69,11 @@ router.post('/', async (req: Request<Record<string, unknown>, Record<string, unk
       const filePath: string = path.resolve(req.body.layout).toLowerCase()
       const isForbiddenFile: boolean = (filePath.includes('ftp') || filePath.includes('ctf.key') || filePath.includes('encryptionkeys'))
       if (!isForbiddenFile) {
-        res.render('dataErasureResult', {
-          ...req.body
-        }, (error, html) => {
+        const templateData = {
+          email: req.body.email,
+          securityAnswer: req.body.securityAnswer
+        };
+        res.render('dataErasureResult', templateData, (error, html) => {
           if (!html || error) {
             next(new Error(error.message))
           } else {
@@ -84,9 +86,11 @@ router.post('/', async (req: Request<Record<string, unknown>, Record<string, unk
         next(new Error('File access not allowed'))
       }
     } else {
-      res.render('dataErasureResult', {
-        ...req.body
-      })
+      const templateData = {
+        email: req.body.email,
+        securityAnswer: req.body.securityAnswer
+      };
+      res.render('dataErasureResult', templateData)
     }
   } catch (error) {
     next(error)

--- a/routes/redirect.ts
+++ b/routes/redirect.ts
@@ -12,8 +12,8 @@ const security = require('../lib/insecurity')
 
 module.exports = function performRedirect () {
   return ({ query }: Request, res: Response, next: NextFunction) => {
-    const toUrl: string = query.to as string
-    if (security.isRedirectAllowed(toUrl)) {
+    const toUrl = typeof query.to === 'string' ? query.to : ''
+    if (toUrl && security.isRedirectAllowed(toUrl)) {
       challengeUtils.solveIf(challenges.redirectCryptoCurrencyChallenge, () => { return toUrl === 'https://explorer.dash.org/address/Xr556RzuwX6hg5EGpkybbv5RanJoZN17kW' || toUrl === 'https://blockchain.info/address/1AbKfgvw9psQ41NbLi8kufDQTezwG8DRZm' || toUrl === 'https://etherscan.io/address/0x0f933ab9fcaaa782d0279c300d73750e1311eae6' })
       challengeUtils.solveIf(challenges.redirectChallenge, () => { return isUnintendedRedirect(toUrl) })
       res.redirect(toUrl)

--- a/routes/showProductReviews.ts
+++ b/routes/showProductReviews.ts
@@ -31,7 +31,7 @@ module.exports = function productReviews () {
 
     // Measure how long the query takes, to check if there was a nosql dos attack
     const t0 = new Date().getTime()
-    db.reviewsCollection.find({ $where: 'this.product == ' + id }).then((reviews: Review[]) => {
+    db.reviewsCollection.find({ product: id }).then((reviews: Review[]) => {
       const t1 = new Date().getTime()
       challengeUtils.solveIf(challenges.noSqlCommandChallenge, () => { return (t1 - t0) > 2000 })
       const user = security.authenticatedUsers.from(req)

--- a/routes/trackOrder.ts
+++ b/routes/trackOrder.ts
@@ -11,10 +11,10 @@ import { challenges } from '../data/datacache'
 
 module.exports = function trackOrder () {
   return (req: Request, res: Response) => {
-    const id = !utils.isChallengeEnabled(challenges.reflectedXssChallenge) ? String(req.params.id).replace(/[^\w-]+/g, '') : req.params.id
+    const id = String(req.params.id).replace(/[^\w-]+/g, '')
 
     challengeUtils.solveIf(challenges.reflectedXssChallenge, () => { return utils.contains(id, '<iframe src="javascript:alert(`xss`)">') })
-    db.ordersCollection.find({ $where: `this.orderId === '${id}'` }).then((order: any) => {
+    db.ordersCollection.find({ orderId: id }).then((order: any) => {
       const result = utils.queryResultToJson(order)
       challengeUtils.solveIf(challenges.noSqlOrdersChallenge, () => { return result.data.length > 1 })
       if (result.data[0] === undefined) {


### PR DESCRIPTION
Fixes 5 code scanning alerts:
- https://github.com/ghas-bootcamp-2024-11-20-cloudlabs100/juice-shop/security/code-scanning/23
  <details>
    <summary>Suggested fix description</summary>
    To fix the problem, we need to ensure that the `query.to` parameter is a string before using it in the `isRedirectAllowed` function. This can be done by adding a type check in `routes/redirect.ts` and modifying the `isRedirectAllowed` function in `lib/insecurity.ts` to handle only string inputs.

    1. In `routes/redirect.ts`, add a type check to ensure `query.to` is a string.
    2. In `lib/insecurity.ts`, modify the `isRedirectAllowed` function to handle only string inputs and return false if the input is not a string.
    
  </details>


- https://github.com/ghas-bootcamp-2024-11-20-cloudlabs100/juice-shop/security/code-scanning/10
  <details>
    <summary>Suggested fix description</summary>
    To fix the problem, we should avoid using the `$where` operator with user-provided input. Instead, we can use a safer query method that does not involve executing JavaScript code. Specifically, we can use the `find` method with a query object that directly matches the `orderId` field. This approach eliminates the risk of code injection.

    We will modify the query on line 17 to use a safer query object. Additionally, we will ensure that the `id` parameter is always sanitized, regardless of the challenge status.
    
  </details>


- https://github.com/ghas-bootcamp-2024-11-20-cloudlabs100/juice-shop/security/code-scanning/9
  <details>
    <summary>Suggested fix description</summary>
    To fix the problem, we need to ensure that user input is properly sanitized before being used in the MongoDB query. Instead of using the `$where` operator with a string concatenation, we can use a parameterized query to safely include the user input. This approach avoids the risk of NoSQL injection by treating the user input as a value rather than executable code.

    We will modify the query to use a parameterized approach with the MongoDB query object.
    
  </details>


- https://github.com/ghas-bootcamp-2024-11-20-cloudlabs100/juice-shop/security/code-scanning/3
  <details>
    <summary>Suggested fix description</summary>
    To fix the problem, we need to avoid using the entire `req.body` object directly in the template rendering. Instead, we should explicitly construct an object with only the necessary properties required by the template. This approach ensures that only the intended data is passed to the template, reducing the risk of template object injection.

    1. Identify the specific properties needed by the `dataErasureResult` template.
    2. Construct an object with only those properties from `req.body`.
    3. Use the constructed object in the `res.render` function instead of `req.body`.
    
  </details>


- https://github.com/ghas-bootcamp-2024-11-20-cloudlabs100/juice-shop/security/code-scanning/2
  <details>
    <summary>Suggested fix description</summary>
    To fix the problem, we need to avoid using the entire `req.body` object directly in the `res.render` method. Instead, we should explicitly construct an object with only the necessary properties required by the template. This approach ensures that only the intended data is passed to the template engine, reducing the risk of template object injection.

    1. Identify the specific properties needed by the `dataErasureResult` template.
    2. Construct an object with only those properties from `req.body`.
    3. Pass the constructed object to `res.render` instead of the entire `req.body`.
    
  </details>


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._