### PR TITLE
Fix 14 code scanning alerts

### DIFF
--- a/data/static/codefixes/unionSqlInjectionChallenge_1.ts
+++ b/data/static/codefixes/unionSqlInjectionChallenge_1.ts
@@ -1,8 +1,10 @@
+const SqlString = require('sqlstring');
+
 module.exports = function searchProducts () {
   return (req: Request, res: Response, next: NextFunction) => {
     let criteria: any = req.query.q === 'undefined' ? '' : req.query.q ?? ''
     criteria = (criteria.length <= 200) ? criteria : criteria.substring(0, 200)
-    criteria.replace(/"|'|;|and|or/i, "")
+    criteria = SqlString.escape(criteria)
     models.sequelize.query(`SELECT * FROM Products WHERE ((name LIKE '%${criteria}%' OR description LIKE '%${criteria}%') AND deletedAt IS NULL) ORDER BY name`)
       .then(([products]: any) => {
         const dataString = JSON.stringify(products)

--- a/lib/accuracy.ts
+++ b/lib/accuracy.ts
@@ -59,6 +59,10 @@ function calculateAccuracy (challengeKey: string, phase: Phase) {
 }
 
 function storeVerdict (challengeKey: string, phase: Phase, verdict: boolean) {
+  if (challengeKey === '__proto__' || challengeKey === 'constructor' || challengeKey === 'prototype') {
+    logger.error(`Invalid challengeKey: ${challengeKey}`)
+    return
+  }
   if (!solves[challengeKey]) {
     solves[challengeKey] = { 'find it': false, 'fix it': false, attempts: { 'find it': 0, 'fix it': 0 } }
   }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -45,7 +45,7 @@ export const endsWith = (str?: string, suffix?: string) => (str && suffix) ? str
 export const contains = (str: string, element: string) => str ? str.includes(element) : false // TODO Inline all usages as this function is not adding any functionality to String.includes
 
 export const containsEscaped = function (str: string, element: string) {
-  return contains(str, element.replace(/"/g, '\\"'))
+  return contains(str, element.replace(/\\/g, '\\\\').replace(/"/g, '\\"'))
 }
 
 export const containsOrEscaped = function (str: string, element: string) {

--- a/package.json
+++ b/package.json
@@ -184,7 +184,8 @@
     "web3": "^4.0.3",
     "winston": "^3.3.3",
     "yaml-schema-validator": "^1.2.2",
-    "z85": "^0.0.2"
+    "z85": "^0.0.2",
+    "sqlstring": "^2.3.3"
   },
   "devDependencies": {
     "@cyclonedx/cyclonedx-npm": "^1.12.0",

--- a/routes/fileServer.ts
+++ b/routes/fileServer.ts
@@ -30,7 +30,14 @@ module.exports = function servePublicFiles () {
       challengeUtils.solveIf(challenges.directoryListingChallenge, () => { return file.toLowerCase() === 'acquisitions.md' })
       verifySuccessfulPoisonNullByteExploit(file)
 
-      res.sendFile(path.resolve('ftp/', file))
+      const safeRoot = path.resolve('ftp/')
+      const resolvedPath = path.resolve(safeRoot, file)
+      if (!resolvedPath.startsWith(safeRoot)) {
+        res.status(403)
+        next(new Error('Access to the requested file is forbidden!'))
+        return
+      }
+      res.sendFile(resolvedPath)
     } else {
       res.status(403)
       next(new Error('Only .md and .pdf files are allowed!'))

--- a/routes/keyServer.ts
+++ b/routes/keyServer.ts
@@ -10,11 +10,14 @@ module.exports = function serveKeyFiles () {
   return ({ params }: Request, res: Response, next: NextFunction) => {
     const file = params.file
 
-    if (!file.includes('/')) {
-      res.sendFile(path.resolve('encryptionkeys/', file))
+    const rootDir = path.resolve('encryptionkeys/')
+    const resolvedPath = path.resolve(rootDir, file)
+
+    if (resolvedPath.startsWith(rootDir)) {
+      res.sendFile(resolvedPath)
     } else {
       res.status(403)
-      next(new Error('File names cannot contain forward slashes!'))
+      next(new Error('Access to the requested file is forbidden!'))
     }
   }
 }

--- a/routes/logfileServer.ts
+++ b/routes/logfileServer.ts
@@ -10,11 +10,14 @@ module.exports = function serveLogFiles () {
   return ({ params }: Request, res: Response, next: NextFunction) => {
     const file = params.file
 
-    if (!file.includes('/')) {
-      res.sendFile(path.resolve('logs/', file))
+    const safeRoot = path.resolve('logs/')
+    const resolvedPath = path.resolve(safeRoot, file)
+
+    if (resolvedPath.startsWith(safeRoot)) {
+      res.sendFile(resolvedPath)
     } else {
       res.status(403)
-      next(new Error('File names cannot contain forward slashes!'))
+      next(new Error('Access to the requested file is forbidden!'))
     }
   }
 }

--- a/routes/quarantineServer.ts
+++ b/routes/quarantineServer.ts
@@ -10,11 +10,14 @@ module.exports = function serveQuarantineFiles () {
   return ({ params, query }: Request, res: Response, next: NextFunction) => {
     const file = params.file
 
-    if (!file.includes('/')) {
-      res.sendFile(path.resolve('ftp/quarantine/', file))
+    const rootFolder = path.resolve('ftp/quarantine/')
+    const resolvedPath = path.resolve(rootFolder, file)
+
+    if (resolvedPath.startsWith(rootFolder) && !file.includes('/')) {
+      res.sendFile(resolvedPath)
     } else {
       res.status(403)
-      next(new Error('File names cannot contain forward slashes!'))
+      next(new Error('Invalid file path!'))
     }
   }
 }

--- a/routes/updateUserProfile.ts
+++ b/routes/updateUserProfile.ts
@@ -2,6 +2,7 @@
  * Copyright (c) 2014-2024 Bjoern Kimminich & the OWASP Juice Shop contributors.
  * SPDX-License-Identifier: MIT
  */
+import { URL } from 'url';
 
 import { type Request, type Response, type NextFunction } from 'express'
 import { UserModel } from '../models/user'
@@ -20,8 +21,10 @@ module.exports = function updateUserProfile () {
       UserModel.findByPk(loggedInUser.data.id).then((user: UserModel | null) => {
         if (user != null) {
           challengeUtils.solveIf(challenges.csrfChallenge, () => {
-            return ((req.headers.origin?.includes('://htmledit.squarefree.com')) ??
-              (req.headers.referer?.includes('://htmledit.squarefree.com'))) &&
+            const allowedHosts = ['htmledit.squarefree.com'];
+            const originHost = req.headers.origin ? new URL(req.headers.origin).host : '';
+            const refererHost = req.headers.referer ? new URL(req.headers.referer).host : '';
+            return (allowedHosts.includes(originHost) || allowedHosts.includes(refererHost)) &&
               req.body.username !== user.username
           })
           void user.update({ username: req.body.username }).then((savedUser: UserModel) => {

--- a/routes/vulnCodeFixes.ts
+++ b/routes/vulnCodeFixes.ts
@@ -3,7 +3,9 @@ import * as accuracy from '../lib/accuracy'
 
 const challengeUtils = require('../lib/challengeUtils')
 const fs = require('fs')
+const path = require('path')
 const yaml = require('js-yaml')
+const ROOT_DIR = path.resolve('./data/static/codefixes')
 
 const FixesDir = 'data/static/codefixes'
 
@@ -76,8 +78,13 @@ export const checkCorrectFix = () => async (req: Request<Record<string, unknown>
     })
   } else {
     let explanation
-    if (fs.existsSync('./data/static/codefixes/' + key + '.info.yml')) {
-      const codingChallengeInfos = yaml.load(fs.readFileSync('./data/static/codefixes/' + key + '.info.yml', 'utf8'))
+    const filePath = path.resolve(ROOT_DIR, key + '.info.yml')
+    if (!filePath.startsWith(ROOT_DIR)) {
+      res.status(403).json({ error: 'Access denied' })
+      return
+    }
+    if (fs.existsSync(filePath)) {
+      const codingChallengeInfos = yaml.load(fs.readFileSync(filePath, 'utf8'))
       const selectedFixInfo = codingChallengeInfos?.fixes.find(({ id }: { id: number }) => id === selectedFix + 1)
       if (selectedFixInfo?.explanation) explanation = res.__(selectedFixInfo.explanation)
     }

--- a/routes/vulnCodeSnippet.ts
+++ b/routes/vulnCodeSnippet.ts
@@ -5,6 +5,7 @@
 
 import { type NextFunction, type Request, type Response } from 'express'
 import fs from 'fs'
+import path from 'path'
 import yaml from 'js-yaml'
 import { getCodeChallenges } from '../lib/codingChallenges'
 import * as accuracy from '../lib/accuracy'
@@ -90,8 +91,14 @@ exports.checkVulnLines = () => async (req: Request<Record<string, unknown>, Reco
   const selectedLines: number[] = req.body.selectedLines
   const verdict = getVerdict(vulnLines, neutralLines, selectedLines)
   let hint
-  if (fs.existsSync('./data/static/codefixes/' + key + '.info.yml')) {
-    const codingChallengeInfos = yaml.load(fs.readFileSync('./data/static/codefixes/' + key + '.info.yml', 'utf8'))
+  const rootDir = path.resolve('./data/static/codefixes')
+  const filePath = path.resolve(rootDir, key + '.info.yml')
+  if (!filePath.startsWith(rootDir)) {
+    res.status(403).json({ status: 'error', error: 'Invalid file path' })
+    return
+  }
+  if (fs.existsSync(filePath)) {
+    const codingChallengeInfos = yaml.load(fs.readFileSync(filePath, 'utf8'))
     if (codingChallengeInfos?.hints) {
       if (accuracy.getFindItAttempts(key) > codingChallengeInfos.hints.length) {
         if (vulnLines.length === 1) {

--- a/server.ts
+++ b/server.ts
@@ -244,7 +244,7 @@ restoreOverwrittenFilesWithOriginals().then(() => {
           } else if (!relativePath.startsWith('.') && currentFolder !== '') {
             relativePath = currentFolder + '/' + relativePath
           } else {
-            relativePath = relativePath.replace('..', '.')
+            relativePath = relativePath.replace(/\.\./g, '.')
           }
           return 'a href="' + relativePath + '"'
         })


### PR DESCRIPTION
Fixes 14 code scanning alerts:
- https://github.com/ghas-bootcamp-2024-11-20-cloudlabs100/juice-shop/security/code-scanning/32
  <details>
    <summary>Suggested fix description</summary>
    To fix the problem, we need to ensure that all occurrences of `'..'` in the `relativePath` string are replaced, not just the first one. This can be achieved by using a regular expression with the global flag (`g`). Specifically, we will replace the line `relativePath = relativePath.replace('..', '.')` with `relativePath = relativePath.replace(/\.\./g, '.')`.
    
  </details>


- https://github.com/ghas-bootcamp-2024-11-20-cloudlabs100/juice-shop/security/code-scanning/31
  <details>
    <summary>Suggested fix description</summary>
    To fix the problem, we need to ensure that backslashes are also escaped in the `containsEscaped` function. This can be done by modifying the regular expression used in the `replace` method to include backslashes. Specifically, we should replace backslashes with double backslashes before replacing double quotes with escaped double quotes. This ensures that all occurrences of backslashes and double quotes are properly escaped.
    
  </details>


- https://github.com/ghas-bootcamp-2024-11-20-cloudlabs100/juice-shop/security/code-scanning/30
  <details>
    <summary>Suggested fix description</summary>
    To fix the problem, we should use a well-tested sanitization library to handle the escaping of meta-characters. In this case, we can use the `sqlstring` library to escape the input criteria properly. This will ensure that all occurrences of meta-characters are escaped, and it will handle edge cases correctly.

    1. Install the `sqlstring` library.
    2. Import the `sqlstring` library in the file.
    3. Use the `SqlString.escape` method to escape the `criteria` before using it in the SQL query.
    
  </details>


- https://github.com/ghas-bootcamp-2024-11-20-cloudlabs100/juice-shop/security/code-scanning/21
  <details>
    <summary>Suggested fix description</summary>
    To fix the problem, we need to ensure that the constructed file path is contained within a safe root folder. We can achieve this by normalizing the path using `path.resolve` to remove any `..` segments and then checking that the normalized path starts with the root folder. This will prevent directory traversal attacks.

    1. Import the `path` module.
    2. Define a constant for the root directory.
    3. Normalize the constructed file path using `path.resolve`.
    4. Check that the normalized path starts with the root directory.
    5. If the check fails, return a 403 status code.
    
  </details>


- https://github.com/ghas-bootcamp-2024-11-20-cloudlabs100/juice-shop/security/code-scanning/20
  <details>
    <summary>Suggested fix description</summary>
    To fix the problem, we need to ensure that the `key` variable is validated and sanitized before it is used to construct the file path. We can use the `path` module to resolve the file path and ensure it is within a designated safe directory. This involves normalizing the path and checking that it starts with the intended root directory.

    1. Import the `path` module.
    2. Define a constant for the root directory where the codefixes are stored.
    3. Use `path.resolve` to normalize the constructed file path.
    4. Check that the resolved path starts with the root directory.
    5. If the path is not valid, return an error response.
    
  </details>


- https://github.com/ghas-bootcamp-2024-11-20-cloudlabs100/juice-shop/security/code-scanning/19
  <details>
    <summary>Suggested fix description</summary>
    To fix the problem, we need to ensure that the constructed file path is contained within a safe root folder. This can be achieved by normalizing the path using `path.resolve` and then checking that the normalized path starts with the root folder. This will prevent any path traversal attempts.

    1. Import the `path` module.
    2. Define a constant for the root directory.
    3. Normalize the constructed file path using `path.resolve`.
    4. Check that the normalized path starts with the root directory.
    5. If the check fails, return an error response.
    
  </details>


- https://github.com/ghas-bootcamp-2024-11-20-cloudlabs100/juice-shop/security/code-scanning/18
  <details>
    <summary>Suggested fix description</summary>
    To fix the problem, we need to ensure that the constructed file path is contained within a safe root folder. We can achieve this by normalizing the path using `path.resolve` and then checking that the normalized path starts with the root folder. This will prevent directory traversal attacks and ensure that the file access is restricted to the intended directory.

    1. Import the `path` module.
    2. Define a constant for the root directory.
    3. Normalize the constructed file path using `path.resolve`.
    4. Check that the normalized path starts with the root directory.
    5. If the check fails, return a 403 status code.
    
  </details>


- https://github.com/ghas-bootcamp-2024-11-20-cloudlabs100/juice-shop/security/code-scanning/17
  <details>
    <summary>Suggested fix description</summary>
    To fix the problem, we need to ensure that the constructed file path is contained within a safe root folder. We can achieve this by normalizing the path using `path.resolve` and then checking that the normalized path starts with the root folder. This will prevent directory traversal attacks by ensuring that the file path cannot escape the intended directory.

    1. Normalize the file path using `path.resolve` to remove any ".." segments.
    2. Check that the normalized path starts with the root folder.
    3. If the path is valid, send the file. Otherwise, return a 403 status code and an error message.
    
  </details>


- https://github.com/ghas-bootcamp-2024-11-20-cloudlabs100/juice-shop/security/code-scanning/15
  <details>
    <summary>Suggested fix description</summary>
    To fix the problem, we need to ensure that the file path constructed from user input is contained within a safe root directory. We can achieve this by normalizing the path using `path.resolve` and then checking that the resulting path starts with the root directory. This will prevent any attempts to navigate outside the intended directory.

    1. Normalize the file path using `path.resolve` to remove any `..` segments.
    2. Check that the normalized path starts with the root directory.
    3. If the check fails, return a 403 status code and an error message.
    
  </details>


- https://github.com/ghas-bootcamp-2024-11-20-cloudlabs100/juice-shop/security/code-scanning/12
  <details>
    <summary>Suggested fix description</summary>
    To fix the problem, we need to ensure that the constructed file path is contained within a safe root folder. We can achieve this by normalizing the path using `path.resolve` and then checking that the normalized path starts with the root folder. This will prevent any attempts to navigate outside the root folder using path traversal techniques.

    1. Normalize the path using `path.resolve` to remove any `..` segments.
    2. Check that the normalized path starts with the root folder.
    3. If the check fails, return a 403 status code and an error message.
    
  </details>


- https://github.com/ghas-bootcamp-2024-11-20-cloudlabs100/juice-shop/security/code-scanning/11
  <details>
    <summary>Suggested fix description</summary>
    To fix the problem, we need to ensure that the constructed file path is contained within a safe root folder. We will normalize the path using `path.resolve` to remove any ".." segments and then check that the normalized path starts with the root folder. This will prevent directory traversal attacks by ensuring that the file path is within the intended directory.

    1. Normalize the file path using `path.resolve`.
    2. Check that the normalized path starts with the root folder.
    3. If the path is not within the root folder, return a 403 status code and an error message.
    
  </details>


- https://github.com/ghas-bootcamp-2024-11-20-cloudlabs100/juice-shop/security/code-scanning/7
  <details>
    <summary>Suggested fix description</summary>
    To fix the problem, we need to parse the `referer` URL and check its host explicitly. This ensures that the host is exactly 'htmledit.squarefree.com' and not just a substring within another URL. We will use the `url` module from Node.js to parse the URL and extract the host for comparison.

    1. Import the `url` module.
    2. Parse the `referer` URL to extract the host.
    3. Compare the extracted host with the allowed host 'htmledit.squarefree.com'.
    
  </details>


- https://github.com/ghas-bootcamp-2024-11-20-cloudlabs100/juice-shop/security/code-scanning/6
  <details>
    <summary>Suggested fix description</summary>
    To fix the problem, we need to parse the URL and check the host explicitly rather than using a substring check. This ensures that the host is exactly what we expect and not part of a larger, potentially malicious URL. We will use the `url` module to parse the URL and then compare the host against a whitelist of allowed hosts.

    1. Import the `url` module.
    2. Parse the `origin` and `referer` headers to extract the host.
    3. Check if the host is in the allowed list of hosts.
    
  </details>


- https://github.com/ghas-bootcamp-2024-11-20-cloudlabs100/juice-shop/security/code-scanning/66
  <details>
    <summary>Suggested fix description</summary>
    The best way to fix the problem is to prevent the `__proto__`, `constructor`, and `prototype` properties from being used as keys in the `solves` object. This can be achieved by adding a check in the `storeVerdict` function to reject these keys.

    - Add a check in the `storeVerdict` function to ensure that `challengeKey` is not `__proto__`, `constructor`, or `prototype`.
    - If the key is one of these values, log an error and return without modifying the `solves` object.
    
  </details>


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._